### PR TITLE
fix(widget): prevent infinite JS loop

### DIFF
--- a/grid-map/src/data_js.js
+++ b/grid-map/src/data_js.js
@@ -11,10 +11,12 @@ function loadTop10() {
             });
         }
     });
-    if (autoRefresh) {
+
+    if (Number(autoRefresh)) {
         if (timeout) {
             clearTimeout(timeout);
         }
+
         timeout = setTimeout(loadTop10, (autoRefresh * 1000));
     }
 }


### PR DESCRIPTION
value of autoRefresh variable is a string and if construction allows to set timer for 0 sec

Resolves CP7M-66