### PR TITLE
fix(UI) use correct color codes (MON-14512)

### DIFF
--- a/grid-map/src/table.php
+++ b/grid-map/src/table.php
@@ -56,10 +56,10 @@ $widgetId = filter_var($_REQUEST['widgetId'], FILTER_VALIDATE_INT);
 
 /* INIT */
 $colors = array(
-    0 => '#8FCF3C',
-    1 => '#ff9a13',
-    2 => '#e00b3d',
-    3 => '#bcbdc0',
+    0 => '#88B917',
+    1 => '#FF9A13',
+    2 => '#E00B3D',
+    3 => '#BCBDC0',
     4 => '#2AD1D4'
 );
 


### PR DESCRIPTION
Hi,

Some color `#codes` are wrong, let's then update them according to the Centreon-2 theme (`www/Themes/Centreon-2/style.css`).

See https://github.com/centreon/centreon-widget-global-health/pull/23 for other related PRs.

Pleaase backport at least up to 19.10.x.

Thank you 👍

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)