### PR TITLE
chore(build): fix build for 21.10

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,6 @@ Please include a short resume of the changes and what is the purpose of PR. Any 
 
 ## Target serie
 
-- [ ] 19.10.x
 - [ ] 20.04.x
 - [ ] 20.10.x
 - [ ] 21.04.x

--- a/grid-map/configs.xml
+++ b/grid-map/configs.xml
@@ -4,7 +4,7 @@
     <email>contact@centreon.com</email>
     <website>http://www.centreon.com</website>
     <description>This grid map widget displays the status of services for a set of hosts. It is possible to select which services to display.</description>
-        <version>21.04.0-beta.1</version>
+        <version>21.10.0</version>
         <keywords>centreon, widget, Grid-map</keywords>
         <screenshot></screenshot>
         <thumbnail>./widgets/Grid-map/resources/logo1.png</thumbnail>


### PR DESCRIPTION
Fixing build for the 21.10.

The version specified in the config.xml is used in the spectemplate of the widget. The spectemplate does not allow -beta.1 as version prefix